### PR TITLE
Use skinCluster input shape and preBindMatrix instead of initial values time

### DIFF
--- a/src/Arguments.cpp
+++ b/src/Arguments.cpp
@@ -40,6 +40,7 @@ const auto animationClipStartTime = "ast";
 const auto animationClipEndTime = "aet";
 
 const auto initialValuesTime = "ivt";
+const auto skinUsePreBindNatrixAndMesh = "pbm";
 
 const auto redrawViewport = "rvp";
 
@@ -165,6 +166,7 @@ SyntaxFactory::SyntaxFactory() {
     registerFlag(ss, flag::animationClipEndTime, "animationClipEndTime", true, kTime);
 
     registerFlag(ss, flag::initialValuesTime, "initialValuesTime", kTime);
+    registerFlag(ss, flag::skinUsePreBindNatrixAndMesh, "skinUsePreBindMatrixAndMesh", kNoArg);
 
     registerFlag(ss, flag::meshPrimitiveAttributes, "meshPrimitiveAttributes", kString);
     registerFlag(ss, flag::blendPrimitiveAttributes, "blendPrimitiveAttributes", kString);
@@ -544,6 +546,7 @@ Arguments::Arguments(const MArgList &args, const MSyntax &syntax) {
 
     initialValuesTime = clipCount > 0 ? MTime(0, MTime::kSeconds) : MAnimControl::currentTime();
     adb.optional(flag::initialValuesTime, initialValuesTime);
+    skinUsePreBindMatrixAndMesh = adb.isFlagSet(flag::skinUsePreBindNatrixAndMesh);
 
     const auto fpsCount = adb.flagUsageCount(flag::animationClipFrameRate);
 

--- a/src/Arguments.cpp
+++ b/src/Arguments.cpp
@@ -40,7 +40,7 @@ const auto animationClipStartTime = "ast";
 const auto animationClipEndTime = "aet";
 
 const auto initialValuesTime = "ivt";
-const auto skinUsePreBindNatrixAndMesh = "pbm";
+const auto skinUsePreBindMatrixAndMesh = "pbm";
 
 const auto redrawViewport = "rvp";
 
@@ -166,7 +166,7 @@ SyntaxFactory::SyntaxFactory() {
     registerFlag(ss, flag::animationClipEndTime, "animationClipEndTime", true, kTime);
 
     registerFlag(ss, flag::initialValuesTime, "initialValuesTime", kTime);
-    registerFlag(ss, flag::skinUsePreBindNatrixAndMesh, "skinUsePreBindMatrixAndMesh", kNoArg);
+    registerFlag(ss, flag::skinUsePreBindMatrixAndMesh, "skinUsePreBindMatrixAndMesh", kNoArg);
 
     registerFlag(ss, flag::meshPrimitiveAttributes, "meshPrimitiveAttributes", kString);
     registerFlag(ss, flag::blendPrimitiveAttributes, "blendPrimitiveAttributes", kString);
@@ -546,7 +546,7 @@ Arguments::Arguments(const MArgList &args, const MSyntax &syntax) {
 
     initialValuesTime = clipCount > 0 ? MTime(0, MTime::kSeconds) : MAnimControl::currentTime();
     adb.optional(flag::initialValuesTime, initialValuesTime);
-    skinUsePreBindMatrixAndMesh = adb.isFlagSet(flag::skinUsePreBindNatrixAndMesh);
+    skinUsePreBindMatrixAndMesh = adb.isFlagSet(flag::skinUsePreBindMatrixAndMesh);
 
     const auto fpsCount = adb.flagUsageCount(flag::animationClipFrameRate);
 

--- a/src/Arguments.h
+++ b/src/Arguments.h
@@ -220,6 +220,12 @@ class Arguments {
      */
     MTime initialValuesTime;
 
+    /**
+     * Use the skinCluster's preBindMatrix values and input mesh for initial base bind 
+     * instead of the visible output mesh from at initialValuesTime.
+     */
+    bool skinUsePreBindMatrixAndMesh = false;
+
     /** Redraw the viewport while exporting? True in debug builds by default,
      * false otherwise (for speed) */
 #ifdef _DEBUG

--- a/src/MeshSkeleton.cpp
+++ b/src/MeshSkeleton.cpp
@@ -49,7 +49,6 @@ MeshSkeleton::MeshSkeleton(ExportableScene &scene, const ExportableNode &node,
         m_joints.reserve(jointCount);
 
         // Gather the relevant input mesh data for the skinCluster
-        
         const auto shapeDagPath = mesh.dagPath(&status);
         THROW_ON_FAILURE(status);
         int inputShapeIndex = fnSkin.indexForOutputShape(mesh.object(), &status);

--- a/src/MeshSkeleton.h
+++ b/src/MeshSkeleton.h
@@ -66,6 +66,10 @@ class MeshSkeleton {
 
     size_t vertexJointAssignmentSetCount() const;
 
+    MDagPath inputShapeDagPath() const { 
+        return m_inputShapeDagPath; 
+    }
+
   private:
     DISALLOW_COPY_MOVE_ASSIGN(MeshSkeleton);
 
@@ -74,6 +78,7 @@ class MeshSkeleton {
     std::vector<VertexJointAssignment> m_vertexJointAssignmentsVector;
     VertexJointAssignmentTable m_vertexJointAssignmentsTable;
     size_t m_maxVertexJointAssignmentCount;
+    MDagPath m_inputShapeDagPath;
 
     static MObject
     tryExtractSkinCluster(const MFnMesh &fnMesh,

--- a/src/MeshSkeleton.h
+++ b/src/MeshSkeleton.h
@@ -66,8 +66,8 @@ class MeshSkeleton {
 
     size_t vertexJointAssignmentSetCount() const;
 
-    MDagPath inputShapeDagPath() const { 
-        return m_inputShapeDagPath; 
+    MObject inputShape() const { 
+        return m_inputShape; 
     }
 
   private:
@@ -78,7 +78,7 @@ class MeshSkeleton {
     std::vector<VertexJointAssignment> m_vertexJointAssignmentsVector;
     VertexJointAssignmentTable m_vertexJointAssignmentsTable;
     size_t m_maxVertexJointAssignmentCount;
-    MDagPath m_inputShapeDagPath;
+    MObject m_inputShape;
 
     static MObject
     tryExtractSkinCluster(const MFnMesh &fnMesh,

--- a/src/MeshVertices.cpp
+++ b/src/MeshVertices.cpp
@@ -169,10 +169,10 @@ MeshVertices::MeshVertices(const MeshIndices &meshIndices, const MeshSkeleton *m
     auto &semantics = meshIndices.semantics;
 
     MFnMesh input_mesh(mesh.dagPath());
-    if (args.skinUsePreBindMatrixAndMesh && meshSkeleton) {
+    if (args.skinUsePreBindMatrixAndMesh && meshSkeleton && !meshSkeleton->inputShape().isNull()) {
        // Retrieve point positions from the input mesh instead of the output of the 
-        std::cout << prefix << "skinUsePreBindMatrixAndMesh - mesh: " << meshSkeleton->inputShapeDagPath().fullPathName() << endl;
-        input_mesh.setObject(meshSkeleton->inputShapeDagPath());
+        std::cout << prefix << "Using skinCluster input geometry shape for base mesh poitn position (flag: skinUsePreBindMatrixAndMesh)" << endl;
+        input_mesh.setObject(meshSkeleton->inputShape());
     }
 
     // Get points

--- a/src/MeshVertices.cpp
+++ b/src/MeshVertices.cpp
@@ -168,11 +168,13 @@ MeshVertices::MeshVertices(const MeshIndices &meshIndices, const MeshSkeleton *m
 
     auto &semantics = meshIndices.semantics;
 
-    MFnMesh input_mesh(mesh.dagPath());
+    MFnMesh input_mesh;
     if (args.skinUsePreBindMatrixAndMesh && meshSkeleton && !meshSkeleton->inputShape().isNull()) {
-       // Retrieve point positions from the input mesh instead of the output of the 
-        std::cout << prefix << "Using skinCluster input geometry shape for base mesh poitn position (flag: skinUsePreBindMatrixAndMesh)" << endl;
+       // Use skincluster input mesh data to retrieve pre-bind point positions and normals
         input_mesh.setObject(meshSkeleton->inputShape());
+    } else {
+        // Use output mesh data at 'initialValuesTime' as bind pose point positions and normals
+        input_mesh.setObject(mesh.dagPath());
     }
 
     // Get points

--- a/src/MeshVertices.cpp
+++ b/src/MeshVertices.cpp
@@ -168,9 +168,16 @@ MeshVertices::MeshVertices(const MeshIndices &meshIndices, const MeshSkeleton *m
 
     auto &semantics = meshIndices.semantics;
 
+    MFnMesh input_mesh(mesh.dagPath());
+    if (args.skinUsePreBindMatrixAndMesh && meshSkeleton) {
+       // Retrieve point positions from the input mesh instead of the output of the 
+        std::cout << prefix << "skinUsePreBindMatrixAndMesh - mesh: " << meshSkeleton->inputShapeDagPath().fullPathName() << endl;
+        input_mesh.setObject(meshSkeleton->inputShapeDagPath());
+    }
+
     // Get points
     MPointArray mPoints;
-    THROW_ON_FAILURE(mesh.getPoints(mPoints, MSpace::kTransform));
+    THROW_ON_FAILURE(input_mesh.getPoints(mPoints, MSpace::kTransform));
     const int numPoints = mPoints.length();
     m_positions.reserve(numPoints);
 
@@ -183,7 +190,7 @@ MeshVertices::MeshVertices(const MeshIndices &meshIndices, const MeshSkeleton *m
 
     const auto positionsSpan = floats(span(m_positions));
     m_table.at(Semantic::POSITION).push_back(positionsSpan);
-
+    
     // Get normals
     auto oppositePlug = mesh.findPlug("opposite", true, &status);
     THROW_ON_FAILURE(status);
@@ -196,7 +203,7 @@ MeshVertices::MeshVertices(const MeshIndices &meshIndices, const MeshSkeleton *m
     const float normalSign = shouldFlipNormals ? -1.0f : 1.0f;
 
     MFloatVectorArray mNormals;
-    THROW_ON_FAILURE(mesh.getNormals(mNormals, MSpace::kWorld));
+    THROW_ON_FAILURE(input_mesh.getNormals(mNormals, MSpace::kWorld));
     const int numNormals = mNormals.length();
     m_normals.reserve(numNormals);
     for (int i = 0; i < numNormals; ++i) {


### PR DESCRIPTION
### Description

This implements an additional boolean flag which allows the exporter to use the input geometry and `preBindMatrix` of the skinCluster node as the base input mesh for any skinned meshes instead of relying on the `initialValuesTime`.

### Note

This is currently a draft PR, rather quick and dirty - it compiles and does something with the flag. But the export isn't correct yet and I still need to identify where it's wrong. Will need to investigate how the preBindMatrix should be converted along with the geo to the correct `inverseBindMatrices` values for GLTF.

Input on code style is welcome too - C++ is not my regular forte.