### PR TITLE
Allow to configure value precisions

### DIFF
--- a/src/Arguments.cpp
+++ b/src/Arguments.cpp
@@ -92,6 +92,13 @@ const auto constantRotationThreshold = "crt";
 const auto constantScalingThreshold = "cst";
 const auto constantWeightsThreshold = "cwt";
 
+const auto posPrecision = "prp";
+const auto dirPrecision = "prd";
+const auto colPrecision = "prc";
+const auto texPrecision = "prt";
+const auto sclPrecision = "prs";
+const auto matPrecision = "prm";
+
 const auto keepObjectNamespace = "kon";
 
 } // namespace flag
@@ -201,6 +208,13 @@ SyntaxFactory::SyntaxFactory() {
     registerFlag(ss, flag::constantRotationThreshold, "constantRotationThreshold", kDouble);
     registerFlag(ss, flag::constantScalingThreshold, "constantScalingThreshold", kDouble);
     registerFlag(ss, flag::constantWeightsThreshold, "constantWeightsThreshold", kDouble);
+
+    registerFlag(ss, flag::posPrecision, "posPrecision", kDouble);
+    registerFlag(ss, flag::dirPrecision, "dirPrecision", kDouble);
+    registerFlag(ss, flag::colPrecision, "colPrecision", kDouble);
+    registerFlag(ss, flag::texPrecision, "texPrecision", kDouble);
+    registerFlag(ss, flag::sclPrecision, "sclPrecision", kDouble);
+    registerFlag(ss, flag::matPrecision, "matPrecision", kDouble);
 
     registerFlag(ss, flag::keepObjectNamespace, "keepMayaNamespaces", kNoArg);
 
@@ -497,6 +511,13 @@ Arguments::Arguments(const MArgList &args, const MSyntax &syntax) {
     adb.optional(flag::constantRotationThreshold, constantRotationThreshold);
     adb.optional(flag::constantScalingThreshold, constantScalingThreshold);
     adb.optional(flag::constantWeightsThreshold, constantWeightsThreshold);
+
+    adb.optional(flag::posPrecision, posPrecision);
+    adb.optional(flag::dirPrecision, dirPrecision);
+    adb.optional(flag::colPrecision, colPrecision);
+    adb.optional(flag::texPrecision, texPrecision);
+    adb.optional(flag::sclPrecision, sclPrecision);
+    adb.optional(flag::matPrecision, matPrecision);
 
     if (!adb.optional(flag::sceneName, sceneName)) {
         // Use filename without extension of current scene file.

--- a/src/Arguments.h
+++ b/src/Arguments.h
@@ -250,6 +250,14 @@ class Arguments {
     /** Consider a blend shape weight animation path as constant if all values are below this threshold */
     double constantWeightsThreshold = 1e-9;
 
+    /** Export precisions */
+    double posPrecision = 1e9;
+    double dirPrecision = 1e9;
+    double colPrecision = 1e9;
+    double texPrecision = 1e9;
+    double sclPrecision = 1e9;
+    double matPrecision = 1e9;
+
     std::vector<AnimClipArg> animationClips;
 
     /** Copyright text of the exported file */

--- a/src/BasicTypes.h
+++ b/src/BasicTypes.h
@@ -24,20 +24,6 @@ const std::array<T, N> &&reinterpret_array(const T (&items)[N]) {
     return std::move(*reinterpret_cast<const std::array<T, N> *>(items));
 }
 
-// const double posPrecision = 1e6;
-// const double dirPrecision = 1e4;
-// const double colPrecision = 1e4;
-// const double texPrecision = 1e4;
-// const double sclPrecision = 1e4;
-// const double matPrecision = 1e6;
-
-const double posPrecision = 1e9;
-const double dirPrecision = 1e9;
-const double colPrecision = 1e9;
-const double texPrecision = 1e9;
-const double sclPrecision = 1e9;
-const double matPrecision = 1e9;
-
 inline double roundTo(const double v, const double precision) {
     return round(v * precision) / precision;
 }

--- a/src/ExportableMesh.cpp
+++ b/src/ExportableMesh.cpp
@@ -154,7 +154,7 @@ ExportableMesh::ExportableMesh(ExportableScene &scene, ExportableNode &node, con
 
                 for (int i = 0; i < 4; ++i) {
                     for (int j = 0; j < 4; ++j) {
-                        inverseBindMatrix[i][j] = roundToFloat(ibm[i][j], matPrecision);
+                        inverseBindMatrix[i][j] = roundToFloat(ibm[i][j], args.matPrecision);
                     }
                 }
 

--- a/src/ExportableNode.cpp
+++ b/src/ExportableNode.cpp
@@ -21,8 +21,11 @@ void ExportableNode::load(ExportableScene &scene, NodeTransformCache &transformC
     bool maybeSegmentScaleCompensation = false;
     DagHelper::getPlugValue(obj, "segmentScaleCompensate", maybeSegmentScaleCompensation);
 
-    // Remember scale factor
+    // Remember scale factor and precision
     scaleFactor = args.getBakeScaleFactor();
+    posPrecision = args.posPrecision;
+    dirPrecision = args.dirPrecision;
+    sclPrecision = args.sclPrecision;
 
     // // Get name
     // const auto name = dagPath.partialPathName(&status);
@@ -103,7 +106,7 @@ void ExportableNode::load(ExportableScene &scene, NodeTransformCache &transformC
     }
 
     // Get transform
-    initialTransformState = transformCache.getTransform(this, scaleFactor);
+    initialTransformState = transformCache.getTransform(this, scaleFactor, posPrecision, sclPrecision, dirPrecision);
     m_glNodes[0].transform = &initialTransformState.localTransforms[0];
     m_glNodes[1].transform = &initialTransformState.localTransforms[1];
 
@@ -152,7 +155,7 @@ ExportableNode::createAnimation(const Arguments &args, const ExportableFrames &f
 }
 
 void ExportableNode::updateNodeTransforms(NodeTransformCache &transformCache) {
-    currentTransformState = transformCache.getTransform(this, scaleFactor);
+    currentTransformState = transformCache.getTransform(this, scaleFactor, posPrecision, sclPrecision, dirPrecision);
     m_glNodes[0].transform = &currentTransformState.localTransforms[0];
     m_glNodes[1].transform = &currentTransformState.localTransforms[1];
 

--- a/src/ExportableNode.h
+++ b/src/ExportableNode.h
@@ -34,6 +34,9 @@ class ExportableNode : public ExportableObject {
     TransformKind transformKind = TransformKind::Simple;
 
     double scaleFactor = 1.0;
+    double posPrecision = 1e9;
+    double dirPrecision = 1e9;
+    double sclPrecision = 1e9;
 
     MPoint pivotPoint;
 

--- a/src/MeshVertices.cpp
+++ b/src/MeshVertices.cpp
@@ -178,7 +178,9 @@ MeshVertices::MeshVertices(const MeshIndices &meshIndices, const MeshSkeleton *m
     for (int i = 0; i < numPoints; ++i) {
         const auto p = mPoints[i] * positionScale;
         m_positions.push_back(
-            {roundToFloat(p.x, posPrecision), roundToFloat(p.y, posPrecision), roundToFloat(p.z, posPrecision)});
+            {roundToFloat(p.x, args.posPrecision), 
+             roundToFloat(p.y, args.posPrecision), 
+             roundToFloat(p.z, args.posPrecision)});
     }
 
     const auto positionsSpan = floats(span(m_positions));
@@ -201,8 +203,9 @@ MeshVertices::MeshVertices(const MeshIndices &meshIndices, const MeshSkeleton *m
     m_normals.reserve(numNormals);
     for (int i = 0; i < numNormals; ++i) {
         auto n = mNormals[i];
-        m_normals.push_back({roundToFloat(normalSign * n.x, dirPrecision), roundToFloat(normalSign * n.y, dirPrecision),
-                             roundToFloat(normalSign * n.z, dirPrecision)});
+        m_normals.push_back({roundToFloat(normalSign * n.x, args.dirPrecision), 
+                             roundToFloat(normalSign * n.y, args.dirPrecision),
+                             roundToFloat(normalSign * n.z, args.dirPrecision)});
     }
 
     const auto normalsSpan = floats(span(m_normals));
@@ -221,8 +224,10 @@ MeshVertices::MeshVertices(const MeshIndices &meshIndices, const MeshSkeleton *m
         for (int i = 0; i < numColors; ++i) {
             const auto &c = mColors[i];
             ;
-            colors.push_back({roundToFloat(c.r, colPrecision), roundToFloat(c.g, colPrecision),
-                              roundToFloat(c.b, colPrecision), roundToFloat(c.a, colPrecision)});
+            colors.push_back({roundToFloat(c.r, args.colPrecision), 
+                              roundToFloat(c.g, args.colPrecision),
+                              roundToFloat(c.b, args.colPrecision), 
+                              roundToFloat(c.a, args.colPrecision)});
         }
 
         const auto colorsSpan = floats(span(colors));
@@ -242,8 +247,8 @@ MeshVertices::MeshVertices(const MeshIndices &meshIndices, const MeshSkeleton *m
         auto &uvSet = m_uvSets[semantic.setIndex] = Float2Vector(uCount);
         for (auto uIndex = 0; uIndex < uCount; uIndex++) {
             auto &uvArray = uvSet[uIndex];
-            uvArray[0] = roundToFloat(uArray[uIndex], texPrecision);
-            uvArray[1] = roundToFloat(1 - vArray[uIndex], texPrecision);
+            uvArray[0] = roundToFloat(uArray[uIndex], args.texPrecision);
+            uvArray[1] = roundToFloat(1 - vArray[uIndex], args.texPrecision);
         }
 
         const auto uvSpan = floats(span(uvSet));
@@ -307,9 +312,9 @@ MeshVertices::MeshVertices(const MeshIndices &meshIndices, const MeshSkeleton *m
                     auto t = mTangents[i];
                     const auto rht = 2 * mesh.isRightHandedTangent(i, &semantic.setName, &status) - 1.0f;
                     THROW_ON_FAILURE(status);
-                    tangentSet.push_back(roundToFloat(t.x, dirPrecision));
-                    tangentSet.push_back(roundToFloat(t.y, dirPrecision));
-                    tangentSet.push_back(roundToFloat(t.z, dirPrecision));
+                    tangentSet.push_back(roundToFloat(t.x, args.dirPrecision));
+                    tangentSet.push_back(roundToFloat(t.y, args.dirPrecision));
+                    tangentSet.push_back(roundToFloat(t.z, args.dirPrecision));
 
                     auto l = t.x * t.x + t.y * t.y + t.z * t.z;
                     if (abs(l - 1) > 1e-6) {

--- a/src/NodeAnimation.cpp
+++ b/src/NodeAnimation.cpp
@@ -58,7 +58,7 @@ NodeAnimation::NodeAnimation(const ExportableNode &node, const ExportableFrames 
 }
 
 void NodeAnimation::sampleAt(const MTime &absoluteTime, const int frameIndex, const int superSampleIndex, NodeTransformCache &transformCache) {
-    auto &transformState = transformCache.getTransform(&node, m_scaleFactor);
+    auto &transformState = transformCache.getTransform(&node, m_scaleFactor, m_arguments.posPrecision, m_arguments.sclPrecision, m_arguments.dirPrecision);
     auto &pTRS = transformState.primaryTRS();
     auto &sTRS = transformState.secondaryTRS();
 

--- a/src/Transform.h
+++ b/src/Transform.h
@@ -95,7 +95,10 @@ class NodeTransformCache {
     ~NodeTransformCache() = default;
 
     const NodeTransformState &getTransform(const ExportableNode *node,
-                                           double scaleFactor);
+                                           double scaleFactor,
+                                           const double posPrecision,
+                                           const double sclPrecision,
+                                           const double dirPrecision);
 
   private:
     DISALLOW_COPY_MOVE_ASSIGN(NodeTransformCache);


### PR DESCRIPTION
### Brief

This implements #192 

### Description

Note that is a relatively quick and dirty refactor. Please confirm this is the cleanest way to do this by passing the values around - it feels a bit odd that `NodeTransformCache.getTransform` now also takes these precision arguments since likely it doesn't cache by those values.

Anyway, some quick tests showed that the configurable options did work. The defaults for the precision remain like so:
In Python:
```python
posPrecision = 1e9
dirPrecision = 1e9
colPrecision = 1e9
texPrecision = 1e9
sclPrecision = 1e9
matPrecision = 1e9
```
In MEL:
```mel
// MEL does not support the 1e notation and thus if exporting with the UI you'll need to write like this too
-posPrecision 1000000000
-dirPrecision 1000000000
-colPrecision 1000000000
-texPrecision 1000000000
-sclPrecision 1000000000
-matPrecision  1000000000
```